### PR TITLE
typo in bip329 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <!-- cargo-rdme start -->
 
-A library for working with [BIP329 labels](https://github.com/bitcoin/bips/blob/master/bip-00329.mediawiki).
+A library for working with [BIP329 labels](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki).
 
 - The main data structure is the [`Labels`](https://docs.rs/bip329/latest/bip329/struct.Labels.html) struct, which is a list of [`Label`](https://docs.rs/bip329/latest/bip329/enum.Label.html) structs.
 - The [`Label`](https://docs.rs/bip329/latest/bip329/enum.Label.html) enum containing all the different types of labels.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A library for working with [BIP329 labels](https://github.com/bitcoin/bips/blob/master/bip-00329.mediawiki).
+//! A library for working with [BIP329 labels](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki).
 //!
 //! - The main data structure is the [`Labels`](crate::Labels) struct, which is a list of [`Label`](crate::Label) structs.
 //! - The [`Label`](crate::Label) enum containing all the different types of labels.


### PR DESCRIPTION
Hi, this is just my way to say hi and fix a typo in URL so that it leads to the correct document, instead of 404.
